### PR TITLE
8 hide cursor circle on mobile devices

### DIFF
--- a/src/components/effects/customcursor.css
+++ b/src/components/effects/customcursor.css
@@ -20,7 +20,6 @@
   transform: translate(-50%, -50%);
   transition: background-color 0.3s;
 }
-/* Create media query for mobile devices to hide the ring around the pointer */
 @media (max-width: 480px) {
   .custom-cursor {
     display: none;


### PR DESCRIPTION
This was set to show the border on the cursor only at 480px or below. 